### PR TITLE
Improve encapsulation for view registration

### DIFF
--- a/app/views/demo/error.jsx
+++ b/app/views/demo/error.jsx
@@ -1,7 +1,7 @@
 import { createElement } from "complate-stream";
 import ApplicationLayout from "../layouts/application.jsx";
 
-export default function DemoError() {
+export function DemoError() {
 	return <ApplicationLayout title="Error Demo Page">
     <h1>This site contains an error</h1>
     <BadJSXError></BadJSXError>

--- a/app/views/demo/index.jsx
+++ b/app/views/demo/index.jsx
@@ -1,7 +1,7 @@
 import { createElement } from "complate-stream";
 import ApplicationLayout from "../layouts/application.jsx";
 
-export default function DemoIndex({ array }) {
+export function DemoIndex({ array }) {
 	return <ApplicationLayout title="Demo Page">
 		<h1>Complate Rails Demo App</h1>
 

--- a/app/views/demo/streaming.jsx
+++ b/app/views/demo/streaming.jsx
@@ -1,7 +1,7 @@
 import { createElement } from "complate-stream";
 import ApplicationLayout from "../layouts/application.jsx";
 
-export default function DemoStreaming({ sleep }) {
+export function DemoStreaming({ sleep }) {
 	return <ApplicationLayout title="Streaming Demo Page">
     <h1>Some Streaming for you</h1>
 		<p>Hope you're using puma...</p>

--- a/app/views/index.js
+++ b/app/views/index.js
@@ -1,9 +1,11 @@
 import Renderer, { createElement } from "complate-stream";
-import registerViews from "./manifest";
+import * as views from "./manifest";
 
 let renderer = new Renderer("<!DOCTYPE html>");
 
-registerViews(renderer);
+Object.values(views).forEach(view => {
+  renderer.registerView(view);
+});
 
 export default (stream, view, params, callback) => {
 	let fragment = params && params._fragment === true;

--- a/app/views/index.js
+++ b/app/views/index.js
@@ -3,8 +3,8 @@ import * as views from "./manifest";
 
 let renderer = new Renderer("<!DOCTYPE html>");
 
-Object.values(views).forEach(view => {
-  renderer.registerView(view);
+Object.keys(views).forEach(viewName => {
+	renderer.registerView(views[viewName]);
 });
 
 export default (stream, view, params, callback) => {

--- a/app/views/manifest.js
+++ b/app/views/manifest.js
@@ -1,4 +1,4 @@
 // This has to list every single view to be used
-export {default as DemoIndex} from './demo/index.jsx';
-export {default as DemoStreaming} from './demo/streaming.jsx';
-export {default as DemoError} from './demo/error.jsx';
+export * from './demo/index.jsx';
+export * from './demo/streaming.jsx';
+export * from './demo/error.jsx';

--- a/app/views/manifest.js
+++ b/app/views/manifest.js
@@ -1,10 +1,8 @@
-// This has to register every single view to be used
+// This has to list every single view to be used
 import DemoIndex from './demo/index.jsx';
 import DemoStreaming from './demo/streaming.jsx';
 import DemoError from './demo/error.jsx';
 
-export default (renderer) => {
-  renderer.registerView(DemoIndex);
-  renderer.registerView(DemoStreaming);
-  renderer.registerView(DemoError);
-}
+export { DemoIndex };
+export { DemoStreaming };
+export { DemoError };

--- a/app/views/manifest.js
+++ b/app/views/manifest.js
@@ -1,8 +1,4 @@
 // This has to list every single view to be used
-import DemoIndex from './demo/index.jsx';
-import DemoStreaming from './demo/streaming.jsx';
-import DemoError from './demo/error.jsx';
-
-export { DemoIndex };
-export { DemoStreaming };
-export { DemoError };
+export {default as DemoIndex} from './demo/index.jsx';
+export {default as DemoStreaming} from './demo/streaming.jsx';
+export {default as DemoError} from './demo/error.jsx';


### PR DESCRIPTION
> this way the manifest module is entirely decoupled from how views end up
> being used - which should also make it easier to (potentially)
> auto-generate that module

4d68a4926f035b18d70c3b984633c064db3c2e88